### PR TITLE
Missing "end of list" in Snocking exercise - Lists.lagda.md

### DIFF
--- a/Padova2025/ProgrammingBasics/Lists.lagda.md
+++ b/Padova2025/ProgrammingBasics/Lists.lagda.md
@@ -130,7 +130,7 @@ map f (x ∷ xs) = f x ∷ map f xs
 
 ## Exercise: Snocking
 
-For instance, `(a ∷ b ∷ c ∷ []) ∷ʳ z` should reduce to `a ∷ b ∷ c ∷ z`.
+For instance, `(a ∷ b ∷ c ∷ []) ∷ʳ z` should reduce to `a ∷ b ∷ c ∷ z ∷ []`.
 
 ```
 _∷ʳ_ : {A : Set} → List A → A → List A


### PR DESCRIPTION
I think the description of the "Snocking" exercise is missing the "end of list" (empty list) in the example provided.

For instance, this submitted code (with "empty list" at the end of the base case)  was accepted:

_∷ʳ_ : {A : Set} → List A → A → List A
[] ∷ʳ c = c ∷ []
(a ∷ b) ∷ʳ c = a ∷ (b ∷ʳ c)

Also, the reference solution was very similar to this.